### PR TITLE
feat: base response entity 구현 (#6)

### DIFF
--- a/hicc-reboot/src/main/java/hiccreboot/backend/common/dto/DataListResponse.java
+++ b/hicc-reboot/src/main/java/hiccreboot/backend/common/dto/DataListResponse.java
@@ -1,0 +1,35 @@
+package hiccreboot.backend.common.dto;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.http.HttpStatusCode;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class DataListResponse<T> extends BaseResponse {
+
+	private final List<T> data;
+	private final int count;
+
+	@Builder
+	protected DataListResponse(boolean isSuccess, HttpStatusCode statusCode, List<T> data) {
+		super(isSuccess, statusCode);
+		this.data = data;
+		this.count = data.size();
+	}
+
+	public static <T> DataListResponse<T> create(List<T> data) {
+		return DataListResponse.<T>builder()
+			.data(data)
+			.build();
+	}
+
+	public static <T> DataListResponse<T> create(T... data) {
+		return DataListResponse.<T>builder()
+			.data(Arrays.asList(data))
+			.build();
+	}
+}

--- a/hicc-reboot/src/main/java/hiccreboot/backend/common/dto/DataResponse.java
+++ b/hicc-reboot/src/main/java/hiccreboot/backend/common/dto/DataResponse.java
@@ -1,0 +1,36 @@
+package hiccreboot.backend.common.dto;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DataResponse<T> extends BaseResponse {
+	private final T data;
+	
+	@Builder
+	protected DataResponse(boolean isSuccess, HttpStatusCode statusCode, T data) {
+		super(isSuccess, statusCode);
+		this.data = data;
+	}
+
+	public static <T> DataResponse<T> ok(T data) {
+		return DataResponse.<T>builder()
+			.isSuccess(true)
+			.statusCode(HttpStatus.OK)
+			.data(data)
+			.build();
+	}
+
+	public static <T> DataResponse<T> ok() {
+		return DataResponse.<T>builder()
+			.isSuccess(true)
+			.statusCode(HttpStatus.OK)
+			.build();
+	}
+}


### PR DESCRIPTION
## 개요
- 기본 반환 개체 구현

## 작업사항
- 구현
  - base response entity
  - data response entity
  - data list response entity
  - error response entity