### PR TITLE
feat: 권한별 접근 제한 (#54)

### DIFF
--- a/hicc-reboot/src/main/java/hiccreboot/backend/common/auth/config/WebSecurityConfig.java
+++ b/hicc-reboot/src/main/java/hiccreboot/backend/common/auth/config/WebSecurityConfig.java
@@ -43,7 +43,10 @@ public class WebSecurityConfig {
 	private final LoginSuccessHandler loginSuccessHandler;
 	private final LoginFailureHandler loginFailureHandler;
 
-	private static String[] ALLOWED_PATTERN = new String[] {
+	private static final String PRESIDENT = "PRESIDENT";
+	private static final String[] PRESIDENT_AND_EXECUTIVE = new String[] {"PRESIDENT", "EXECUTIVE"};
+
+	private static final String[] ALLOWED_PATTERN = new String[] {
 		"/api/auth/login/**",
 		"/api/auth/sign-up/**",
 		"/api/auth/duplicate/**",
@@ -65,6 +68,8 @@ public class WebSecurityConfig {
 					.map(AntPathRequestMatcher::antMatcher)
 					.toArray(AntPathRequestMatcher[]::new))
 				.permitAll()
+				.requestMatchers(AntPathRequestMatcher.antMatcher("/api/admin/president/**")).hasRole(PRESIDENT)
+				.requestMatchers(AntPathRequestMatcher.antMatcher("/api/admin/**")).hasAnyRole(PRESIDENT_AND_EXECUTIVE)
 				.anyRequest()
 				.authenticated()) // for develop
 			.logout(httpSecurityLogoutConfigurer -> httpSecurityLogoutConfigurer

--- a/hicc-reboot/src/main/java/hiccreboot/backend/controller/AdminController.java
+++ b/hicc-reboot/src/main/java/hiccreboot/backend/controller/AdminController.java
@@ -9,10 +9,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import hiccreboot.backend.common.auth.jwt.TokenProvider;
 import hiccreboot.backend.common.dto.BaseResponse;
 import hiccreboot.backend.common.dto.DataResponse;
 import hiccreboot.backend.dto.request.ModifyGradeRequest;
 import hiccreboot.backend.service.MemberService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -22,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 public class AdminController {
 
 	private final MemberService memberService;
+	private final TokenProvider tokenProvider;
 
 	@GetMapping("/applicants")
 	public BaseResponse findApplicants(@RequestParam(value = "page") int page, @RequestParam(value = "size") int size) {
@@ -51,15 +54,17 @@ public class AdminController {
 
 	@PatchMapping("/president/members/{member-id}")
 	public BaseResponse modifyGrade(@PathVariable(value = "member-id") Long memberId,
-		@Valid @RequestBody ModifyGradeRequest request) {
-		memberService.modifyGrade(memberId, request.getGrade());
+		@Valid @RequestBody ModifyGradeRequest request, HttpServletRequest servletRequest) {
+		String presidentStudentNumber = tokenProvider.extractStudentNumber(servletRequest).get();
+		memberService.modifyGrade(memberId, request.getGrade(), presidentStudentNumber);
 
 		return DataResponse.ok();
 	}
 
 	@DeleteMapping("/president/members/{member-id}")
-	public BaseResponse expel(@PathVariable(value = "member-id") Long memberId) {
-		memberService.expel(memberId);
+	public BaseResponse expel(@PathVariable(value = "member-id") Long memberId, HttpServletRequest servletRequest) {
+		String presidentStudentNumber = tokenProvider.extractStudentNumber(servletRequest).get();
+		memberService.expel(memberId, presidentStudentNumber);
 
 		return DataResponse.noContent();
 	}

--- a/hicc-reboot/src/main/java/hiccreboot/backend/service/MemberService.java
+++ b/hicc-reboot/src/main/java/hiccreboot/backend/service/MemberService.java
@@ -101,17 +101,18 @@ public class MemberService {
 		return DataResponse.ok(result);
 	}
 
-	public void modifyGrade(Long modifiedMemberId, Grade grade) {
+	public void modifyGrade(Long modifiedMemberId, Grade grade, String presidentStudentNumber) {
 		memberRepository.findById(modifiedMemberId)
-			.filter(memberNotPresident -> !memberNotPresident.getGrade().equals(Grade.PRESIDENT))
+			.filter(modifiedMember -> validateTargetNotRequester(modifiedMember, presidentStudentNumber))
+			.filter(modifiedMember -> validateModifyAnotherGrade(modifiedMember, grade))
 			.ifPresentOrElse(member -> member.updateGrade(grade), () -> {
 				throw MemberNotFoundException.EXCEPTION;
 			});
 	}
 
-	public void expel(Long deletedMemberId) {
+	public void expel(Long deletedMemberId, String presidentStudentNumber) {
 		memberRepository.findById(deletedMemberId)
-			.filter(memberNotPresident -> !memberNotPresident.getGrade().equals(Grade.PRESIDENT))
+			.filter(deletedMember -> validateTargetNotRequester(deletedMember, presidentStudentNumber))
 			.ifPresentOrElse(memberRepository::delete, () -> {
 				throw MemberNotFoundException.EXCEPTION;
 			});
@@ -125,5 +126,13 @@ public class MemberService {
 		} else {
 			return Sort.by("grade");
 		}
+	}
+
+	private boolean validateTargetNotRequester(Member member, String requesterStudentNumber) {
+		return !member.getStudentNumber().equals(requesterStudentNumber);
+	}
+
+	private boolean validateModifyAnotherGrade(Member modifiedMember, Grade modifiedGrade) {
+		return !modifiedMember.getGrade().equals(modifiedGrade);
 	}
 }


### PR DESCRIPTION
## 개요
- close #54

## 작업사항
- Web Security Filter Chain 수정
  - 관리 페이지에 대해 권한별 접근 권한 설정
- 회원 권한 수정,회원 탈퇴 로직 수정
  - 기존에는 회장의 권한을 수정하거나 회장을 탈퇴시킬 수 없었으나
  이제는 요청자를 제외한 모두를 처리할 수 있도록 변경