### PR TITLE
feat: 회원 등급을 회장으로 수정 시 회장 위임 (#119)

### DIFF
--- a/hicc-reboot/src/main/java/hiccreboot/backend/service/MemberService.java
+++ b/hicc-reboot/src/main/java/hiccreboot/backend/service/MemberService.java
@@ -13,6 +13,8 @@ import hiccreboot.backend.common.dto.DataResponse;
 import hiccreboot.backend.common.exception.DepartmentNotFoundException;
 import hiccreboot.backend.common.exception.MemberNotFoundException;
 import hiccreboot.backend.common.exception.StudentDuplicateException;
+import hiccreboot.backend.domain.Article;
+import hiccreboot.backend.domain.Comment;
 import hiccreboot.backend.domain.Department;
 import hiccreboot.backend.domain.Grade;
 import hiccreboot.backend.domain.Member;
@@ -152,13 +154,10 @@ public class MemberService {
 
 	private void deleteMember(Member deletedMember) {
 		articleRepository.findAllByMember(deletedMember)
-			.forEach(article -> {
-				article.deleteArticleSoftly();
-			});
+			.forEach(Article::deleteArticleSoftly);
+
 		commentRepository.findAllByMember(deletedMember)
-			.forEach(comment -> {
-				comment.deleteCommentSoftly();
-			});
+			.forEach(Comment::deleteCommentSoftly);
 
 		memberRepository.delete(deletedMember);
 	}

--- a/hicc-reboot/src/main/java/hiccreboot/backend/service/MemberService.java
+++ b/hicc-reboot/src/main/java/hiccreboot/backend/service/MemberService.java
@@ -126,10 +126,7 @@ public class MemberService {
 
 		memberRepository.findById(modifiedMemberId)
 			.filter(modifiedMember -> validateTargetNotRequester(modifiedMember, presidentStudentNumber))
-			.filter(modifiedMember -> validateModifyAnotherGrade(modifiedMember, grade))
-			.ifPresentOrElse(member -> member.updateGrade(grade), () -> {
-				throw MemberNotFoundException.EXCEPTION;
-			});
+			.ifPresent(modifiedMember -> modifiedMember.updateGrade(grade));
 	}
 
 	private void handOverPresident(Long modifiedMemberId, String presidentStudentNumber) {
@@ -175,10 +172,6 @@ public class MemberService {
 
 	private boolean validateTargetNotRequester(Member member, String requesterStudentNumber) {
 		return !member.getStudentNumber().equals(requesterStudentNumber);
-	}
-
-	private boolean validateModifyAnotherGrade(Member modifiedMember, Grade modifiedGrade) {
-		return !modifiedMember.getGrade().equals(modifiedGrade);
 	}
 
 	public DataResponse<ProfileMemberResponse> getProfile(String studentNumber) {


### PR DESCRIPTION
## 개요
- close #119

## 작업사항
- 구현
  - 회장으로 등급 변경 시 회장 직위 해제 및 위임 기능 구현

-  개선
   - 회원 삭제 로직 람다식 사용
   - 불필요한 검증 메소드 제거
   - 불필요한 예외 발생 제거
