### PR TITLE
fix: 의존성 중복 제거, 시작 시간으로 일정 조회 정렬 적용

### DIFF
--- a/hicc-reboot/src/main/java/hiccreboot/backend/common/auth/config/WebSecurityConfig.java
+++ b/hicc-reboot/src/main/java/hiccreboot/backend/common/auth/config/WebSecurityConfig.java
@@ -47,8 +47,6 @@ public class WebSecurityConfig {
 
 	private final CorsConfigurationSource corsConfigurationSource;
 
-	private final CorsConfigurationSource corsConfigurationSource;
-
 	private static final String PRESIDENT = "PRESIDENT";
 	private static final String[] PRESIDENT_AND_EXECUTIVE = new String[] {"PRESIDENT", "EXECUTIVE"};
 

--- a/hicc-reboot/src/main/java/hiccreboot/backend/domains/calendar/service/CalendarService.java
+++ b/hicc-reboot/src/main/java/hiccreboot/backend/domains/calendar/service/CalendarService.java
@@ -59,7 +59,8 @@ public class CalendarService {
 	}
 
 	public DataResponse<ScheduleResponse> makeSchedule(Long id) {
-		Schedule schedule = scheduleRepository.findById(id).orElseThrow(() -> ScheduleNotFoundException.EXCEPTION);
+		Schedule schedule = scheduleRepository.findById(id)
+			.orElseThrow(() -> ScheduleNotFoundException.EXCEPTION);
 
 		return DataResponse.ok(
 			ScheduleResponse.create(schedule));
@@ -77,7 +78,8 @@ public class CalendarService {
 
 		LocalDate startDate = postScheduleRequest.getStartDateTime().toLocalDate();
 		LocalDate endDate = postScheduleRequest.getEndDateTime().toLocalDate();
-		startDate.datesUntil(endDate.plusDays(1)).forEach(localDate -> ScheduleDate.create(localDate, schedule));
+		startDate.datesUntil(endDate.plusDays(1))
+			.forEach(localDate -> ScheduleDate.create(localDate, schedule));
 
 		scheduleRepository.save(schedule);
 	}
@@ -100,7 +102,8 @@ public class CalendarService {
 		checkCalendarAuthority(member.getGrade());
 		validateDates(updateScheduleRequest.getStartDateTime(), updateScheduleRequest.getEndDateTime());
 
-		Schedule schedule = scheduleRepository.findById(id).orElseThrow(() -> ScheduleNotFoundException.EXCEPTION);
+		Schedule schedule = scheduleRepository.findById(id)
+			.orElseThrow(() -> ScheduleNotFoundException.EXCEPTION);
 
 		//schedule 변경
 		schedule.updateName(updateScheduleRequest.getName());

--- a/hicc-reboot/src/main/java/hiccreboot/backend/domains/calendar/service/CalendarService.java
+++ b/hicc-reboot/src/main/java/hiccreboot/backend/domains/calendar/service/CalendarService.java
@@ -127,10 +127,9 @@ public class CalendarService {
 	}
 
 	private void validateDates(LocalDateTime startDateTime, LocalDateTime endDateTime) {
-		if (!endDateTime.isBefore(startDateTime)) {
-			return;
+		if (startDateTime.isAfter(endDateTime)) {
+			throw DateTimePreconditionFailed.EXCEPTION;
 		}
-		throw DateTimePreconditionFailed.EXCEPTION;
 	}
 
 }

--- a/hicc-reboot/src/main/java/hiccreboot/backend/domains/calendar/service/CalendarService.java
+++ b/hicc-reboot/src/main/java/hiccreboot/backend/domains/calendar/service/CalendarService.java
@@ -2,6 +2,7 @@ package hiccreboot.backend.domains.calendar.service;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -35,7 +36,9 @@ public class CalendarService {
 	private final MemberRepository memberRepository;
 
 	public DataResponse<List<ScheduleResponse>> makeMonthSchedules(int year, int month) {
-		List<ScheduleResponse> scheduleResponses = scheduleRepository.findAllByYearAndMonth(year, month).stream()
+		List<ScheduleResponse> scheduleResponses = scheduleRepository.findAllByYearAndMonth(year, month)
+			.stream()
+			.sorted(Comparator.comparing(Schedule::getStartDateTime))
 			.map(ScheduleResponse::create)
 			.toList();
 
@@ -45,6 +48,7 @@ public class CalendarService {
 	public DataResponse<List<ScheduleDateResponse>> findScheduleByDate(int year, int month, int day) {
 		List<ScheduleDateResponse> result = scheduleDateRepository.findAllByYearAndMonthAndDayOfMonth(year, month, day)
 			.stream()
+			.sorted(Comparator.comparing(scheduleDate -> scheduleDate.getSchedule().getStartDateTime()))
 			.map(ScheduleDateResponse::create)
 			.toList();
 

--- a/hicc-reboot/src/main/java/hiccreboot/backend/domains/calendar/service/CalendarService.java
+++ b/hicc-reboot/src/main/java/hiccreboot/backend/domains/calendar/service/CalendarService.java
@@ -90,7 +90,7 @@ public class CalendarService {
 	}
 
 	@Transactional
-	public Schedule updateSchedule(String studentNumber, Long id, UpdateScheduleRequest updateScheduleRequest) {
+	public void updateSchedule(String studentNumber, Long id, UpdateScheduleRequest updateScheduleRequest) {
 		Member member = memberRepository.findByStudentNumber(studentNumber)
 			.orElseThrow(() -> MemberNotFoundException.EXCEPTION);
 
@@ -109,9 +109,8 @@ public class CalendarService {
 		schedule.getScheduleDates().clear();
 		LocalDate startDate = updateScheduleRequest.getStartDateTime().toLocalDate();
 		LocalDate endDate = updateScheduleRequest.getEndDateTime().toLocalDate();
-		startDate.datesUntil(endDate.plusDays(1)).forEach(localDate -> ScheduleDate.create(localDate, schedule));
-
-		return schedule;
+		startDate.datesUntil(endDate.plusDays(1))
+			.forEach(localDate -> ScheduleDate.create(localDate, schedule));
 	}
 
 	private void checkCalendarAuthority(Grade grade) {

--- a/hicc-reboot/src/main/java/hiccreboot/backend/domains/calendar/service/CalendarService.java
+++ b/hicc-reboot/src/main/java/hiccreboot/backend/domains/calendar/service/CalendarService.java
@@ -63,7 +63,7 @@ public class CalendarService {
 	}
 
 	@Transactional
-	public Schedule saveSchedule(String studentNumber, PostScheduleRequest postScheduleRequest) {
+	public void saveSchedule(String studentNumber, PostScheduleRequest postScheduleRequest) {
 		Member member = memberRepository.findByStudentNumber(studentNumber)
 			.orElseThrow(() -> MemberNotFoundException.EXCEPTION);
 
@@ -77,7 +77,6 @@ public class CalendarService {
 		startDate.datesUntil(endDate.plusDays(1)).forEach(localDate -> ScheduleDate.create(localDate, schedule));
 
 		scheduleRepository.save(schedule);
-		return schedule;
 	}
 
 	@Transactional

--- a/hicc-reboot/src/main/java/hiccreboot/backend/domains/calendar/service/CalendarService.java
+++ b/hicc-reboot/src/main/java/hiccreboot/backend/domains/calendar/service/CalendarService.java
@@ -123,7 +123,7 @@ public class CalendarService {
 	}
 
 	private void validateDates(LocalDateTime startDateTime, LocalDateTime endDateTime) {
-		if (endDateTime.compareTo(startDateTime) >= 0) {
+		if (!endDateTime.isBefore(startDateTime)) {
 			return;
 		}
 		throw DateTimePreconditionFailed.EXCEPTION;

--- a/hicc-reboot/src/main/java/hiccreboot/backend/domains/calendar/service/CalendarService.java
+++ b/hicc-reboot/src/main/java/hiccreboot/backend/domains/calendar/service/CalendarService.java
@@ -38,7 +38,7 @@ public class CalendarService {
 	public DataResponse<List<ScheduleResponse>> makeMonthSchedules(int year, int month) {
 		List<ScheduleResponse> scheduleResponses = scheduleRepository.findAllByYearAndMonth(year, month)
 			.stream()
-			.sorted(Comparator.comparing(Schedule::getStartDateTime))
+			.sorted(Comparator.comparing(schedule -> schedule.getStartDateTime().toLocalTime()))
 			.map(ScheduleResponse::create)
 			.toList();
 
@@ -48,7 +48,10 @@ public class CalendarService {
 	public DataResponse<List<ScheduleDateResponse>> findScheduleByDate(int year, int month, int day) {
 		List<ScheduleDateResponse> result = scheduleDateRepository.findAllByYearAndMonthAndDayOfMonth(year, month, day)
 			.stream()
-			.sorted(Comparator.comparing(scheduleDate -> scheduleDate.getSchedule().getStartDateTime()))
+			.sorted(Comparator.comparing(scheduleDate -> scheduleDate
+				.getSchedule()
+				.getStartDateTime()
+				.toLocalTime()))
 			.map(ScheduleDateResponse::create)
 			.toList();
 


### PR DESCRIPTION
## 개요
- close #142 

## 작업사항
- 수정
  - 의존성 주입 중복 제거
  - 시작 시간으로 일정 조회 정렬 적용
- 리팩토링
  - CalendarService