### PR TITLE
fix: 회원 가입 시 이름 정규식 수정

### DIFF
--- a/hicc-reboot/src/main/java/hiccreboot/backend/domains/auth/dto/request/SignUpRequest.java
+++ b/hicc-reboot/src/main/java/hiccreboot/backend/domains/auth/dto/request/SignUpRequest.java
@@ -18,7 +18,7 @@ public class SignUpRequest {
 	private String studentNumber;
 
 	@NotNull
-	@Pattern(regexp = "[a-zA-Z가-힣]{1,6}", message = "이름을 확인해주세요.")
+	@Pattern(regexp = "[가-힣]{2,7}", message = "이름을 확인해주세요.")
 	private String name;
 
 	@NotNull


### PR DESCRIPTION
## 개요
- close #145 

## 작업사항
- 이름 글자수 제한을 2자 이상 7자 이하로 수정

## 참고
![image](https://github.com/HICC-REBOOT/HICC-REBOOT-Backend/assets/55966515/7687ef11-cfbb-436a-b4f9-2c4b8666037f)
